### PR TITLE
update libartnet; fix check for empty ip in artnet_net_init

### DIFF
--- a/libs/artnet/private.h
+++ b/libs/artnet/private.h
@@ -100,7 +100,9 @@ extern uint16_t HIGH_BYTE;
 #endif
 
 // byte ordering macros
+#ifndef bswap_16
 #define bswap_16(x)  ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8))
+#endif
 
 // htols : convert short from host to little endian order
 #ifdef WIN32

--- a/libs/artnet/receive.c
+++ b/libs/artnet/receive.c
@@ -828,7 +828,7 @@ int handle(node n, artnet_packet p) {
       break;
     default:
       n->state.report_code = ARTNET_RCPARSEFAIL;
-      printf("artnet but not yet implemented!, op was %hx\n", p->type);
+      printf("artnet but not yet implemented!, op was %x\n", (int) p->type);
   }
   return 0;
 }

--- a/libs/artnet/transmit.c
+++ b/libs/artnet/transmit.c
@@ -87,7 +87,7 @@ int artnet_tx_poll_reply(node n, int response) {
 
   snprintf((char *) &reply.data.ar.nodereport,
            sizeof(reply.data.ar.nodereport),
-           "%04hx [%04i] libartnet",
+           "%04x [%04i] libartnet",
            n->state.report_code,
            n->state.ar_count);
 


### PR DESCRIPTION
update libartnet to a more recent version

fix check for preferred ip in artnet_net_init so it’s possible to initialize the node without explicitly providing an ip address