### PR TITLE
return node setup status

### DIFF
--- a/src/ofxLibArtnet.cpp
+++ b/src/ofxLibArtnet.cpp
@@ -15,7 +15,7 @@ void Node::addUniverses(int _num) {
     
 }
 
-void Node::setup(string _ip_addr, bool _sendRaw, uint8_t _subnet_addr)
+bool Node::setup(string _ip_addr, bool _sendRaw, uint8_t _subnet_addr)
 {
     ip_addr = _ip_addr;
     subnet_addr = _subnet_addr;
@@ -26,7 +26,8 @@ void Node::setup(string _ip_addr, bool _sendRaw, uint8_t _subnet_addr)
     
     if (!artnetNode) {
         printf("Error: %s\n", artnet_strerror());
-        std::exit(-1);
+        //std::exit(-1);
+        return false;
     }
     
     artnet_set_long_name(artnetNode, "ofxLibArtnet");
@@ -55,9 +56,11 @@ void Node::setup(string _ip_addr, bool _sendRaw, uint8_t _subnet_addr)
     
     if (artnet_start(artnetNode) != 0) {
         printf("Error: %s\n", artnet_strerror());
-        std::exit(-1);
+        //std::exit(-1);
+        return false;
     }  
     
+    return true;
 };
 
 void Node::updateData(unsigned char * _data, int _length) {

--- a/src/ofxLibArtnet.h
+++ b/src/ofxLibArtnet.h
@@ -44,7 +44,7 @@ class Node
 public:
     
     void    addUniverses(int _num);
-    void    setup(string _ip_addr, bool _sendRaw = false, uint8_t _subnet_addr = 0);
+    bool    setup(string _ip_addr, bool _sendRaw = false, uint8_t _subnet_addr = 0);
     
     void    updateData(unsigned char * _data, int _length);
     void    updateDataByIndex(int _index, unsigned char * _data, int _length);


### PR DESCRIPTION
Return false on node setup instead of quitting everything if it fails; return true on success.
this will leave it to the app to decide what to do when the artnet node setup failed, often when a network interface is not available (i.e. retry later automatically or via UI action, or just disable the artnet output feature)
